### PR TITLE
Fix: Read req/res body only if logBody config option is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,16 @@ Default 2000. If batching is not disabled, this is the maximum wait time (approx
 Type: number of time to retry if fails to post to Moesif.
 If set, must be a number between 0 to 3.
 
+#### __`requestMaxBodySizeLimit`__
+
+Type: number
+Default 100000. Maximum request body size in bytes to log when sending the data to Moesif.
+
+#### __`responseMaxBodySizeLimit`__
+
+Type: number
+Default 100000. Maximum response body size in bytes to log when sending the data to Moesif.
+
 ## Capture Outgoing
 
 If you want to capture all outgoing API calls from your Node.js app to third parties like

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@ var PassThrough = require('stream').PassThrough;
 var moesifConfigManager = require('./moesifConfigManager');
 var uuid4 = require('uuid4');
 var unparsed = require('koa-body/unparsed.js');
+var pjson = require('../package.json');
 
 // express converts headers to lowercase
 const TRANSACTION_ID_HEADER = 'x-moesif-transaction-id';
@@ -95,6 +96,7 @@ module.exports = function(options) {
   // config moesifapi
   var config = moesifapi.configuration;
   config.ApplicationId = options.applicationId || options.ApplicationId;
+  config.UserAgent = 'moesif-nodejs/' + pjson.version
   config.BaseUri = options.baseUri || options.BaseUri || config.BaseUri;
   // default retry to 1.
   config.retry = isNil(options.retry) ?  1 : options.retry;
@@ -155,6 +157,8 @@ module.exports = function(options) {
 
   options.batchSize = options.batchSize || 25;
   options.batchMaxTime = options.batchMaxTime || 2000;
+  options.requestMaxBodySizeLimit = options.requestMaxBodySizeLimit || 100000;
+  options.responseMaxBodySizeLimit = options.responseMaxBodySizeLimit || 100000;
 
   if (options.disableBatching) {
     batcher = null;
@@ -275,6 +279,7 @@ module.exports = function(options) {
     // declare getRawBodyPromise here so in scope.
 
     if (
+      config.logBody &&
       !req.body &&
       req.headers &&
       req.headers['content-type'] &&
@@ -351,14 +356,13 @@ module.exports = function(options) {
     logMessage(options.debug, 'addTxIdToResponse took time ', timeTookInSeconds(addTxIdToResponseStartTime, addTxIdToResponseEndTime));
 
     res.end = function(chunk, encoding, callback) {
-      logMessage(options.debug, 'response end', 'append chunk=' + chunk);
-
       var finalBuf = resBodyBuf;
 
       res.time = new Date();
       res.responseTime = new Date() - req._startTime;
 
-      if (chunk && typeof chunk !== 'function') {
+      if (chunk && typeof chunk !== 'function' && options.logBody && (chunk.length < options.responseMaxBodySizeLimit)) {
+        logMessage(options.debug, 'response end', 'append chunk=' + chunk);
         finalBuf = Buffer.from(appendChunk(resBodyBuf, chunk));
       }
 
@@ -546,7 +550,7 @@ function logEvent(chunk, req, res, options, saveEvent) {
       logData.request.body = req._moBody;
       var parseRequestBodyAsTransferEncodingEndTime = Date.now();
       logMessage(options.debug, 'parseRequestBodyAsTransferEncoding took time ', timeTookInSeconds(parseRequestBodyAsTransferEncodingStartTime, parseRequestBodyAsTransferEncodingEndTime));
-    } else if (req.body) {
+    } else if (req.body && (Number(Buffer.byteLength(JSON.stringify(req.body)) < options.requestMaxBodySizeLimit))) {
       logMessage(options.debug, 'logEvent', 'processing req.body');
       var isReqBodyMaybeJson = isJsonHeader(req) || startWithJson(req.body);
 
@@ -718,10 +722,16 @@ function ensureValidOptions(options) {
     throw new Error('If retry is set, it must be a number between 0 to 3.');
   }
   if (options.batchSize && (!isNumber(options.batchSize) || options.batchSize <= 1)) {
-    throw new Error('batchSize must be a number great than 1');
+    throw new Error('batchSize must be a number greater than or equal to 1');
   }
   if (options.batchMaxTime && (!isNumber(options.batchMaxTime) || options.batchMaxTime <= 500)) {
     throw new Error('batchMaxTime must be greater than 500 milliseonds');
+  }
+  if (options.requestMaxBodySizeLimit && (!isNumber(options.requestMaxBodySizeLimit) || options.requestMaxBodySizeLimit < 0)) {
+    throw new Error('requestMaxBodySizeLimit must be a number greater than 0');
+  }
+  if (options.responseMaxBodySizeLimit && (!isNumber(options.responseMaxBodySizeLimit) || options.responseMaxBodySizeLimit < 0)) {
+    throw new Error('responseMaxBodySizeLimit must be a number greater than 0');
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,12 +105,12 @@ module.exports = function(options) {
   var identifyUserStartTime = Date.now();
   options.identifyUser = options.identifyUser || defaultIdentifyUser;
   var identifyUserEndTime = Date.now();
-  logMessage(options.debug, 'identifyUser took time ', timeTookInSeconds(identifyUserStartTime, identifyUserEndTime));  
-  
+  logMessage(options.debug, 'identifyUser took time ', timeTookInSeconds(identifyUserStartTime, identifyUserEndTime));
+
   var identifyCompanyStartTime = Date.now();
   options.identifyCompany = options.identifyCompany || noop;
   var identifyCompanyEndTime = Date.now();
-  logMessage(options.debug, 'identifyCompany took time ', timeTookInSeconds(identifyCompanyStartTime, identifyCompanyEndTime));  
+  logMessage(options.debug, 'identifyCompany took time ', timeTookInSeconds(identifyCompanyStartTime, identifyCompanyEndTime));
 
   // function to add custom metadata (must be an object that can be converted to JSON)
   options.getMetadata = options.getMetadata || noop;
@@ -147,7 +147,7 @@ module.exports = function(options) {
       return false;
     };
 
-  var skipStartTime = Date.now();  
+  var skipStartTime = Date.now();
   // function where conditions can be declared, when a request should be skipped and not be tracked by moesif
   options.skip = options.skip || exports.defaultSkip;
   var skipEndTime = Date.now();
@@ -279,7 +279,7 @@ module.exports = function(options) {
     // declare getRawBodyPromise here so in scope.
 
     if (
-      config.logBody &&
+      options.logBody &&
       !req.body &&
       req.headers &&
       req.headers['content-type'] &&
@@ -328,11 +328,15 @@ module.exports = function(options) {
     var resBodyBuf;
 
     var responseWriteAppendChunkStartTime = Date.now();
-    res.write = function(chunk, encoding, callback) {
-      logMessage(options.debug, 'response write', 'append chunk=' + chunk);
-      resBodyBuf = appendChunk(resBodyBuf, chunk);
-      res._mo_write(chunk, encoding, callback);
-    };
+
+    if (options.logBody) {
+      // we only need to patch res.write if we are logBody
+      res.write = function(chunk, encoding, callback) {
+        logMessage(options.debug, 'response write', 'append chunk=' + chunk);
+        resBodyBuf = appendChunk(resBodyBuf, chunk);
+        res._mo_write(chunk, encoding, callback);
+      };
+    }
     var responseWriteAppendChunkEndTime = Date.now();
     logMessage(options.debug, 'responseWriteAppendChunk took time ', timeTookInSeconds(responseWriteAppendChunkStartTime, responseWriteAppendChunkEndTime));
 
@@ -361,9 +365,14 @@ module.exports = function(options) {
       res.time = new Date();
       res.responseTime = new Date() - req._startTime;
 
-      if (chunk && typeof chunk !== 'function' && options.logBody && (chunk.length < options.responseMaxBodySizeLimit)) {
+      if (chunk && typeof chunk !== 'function') {
         logMessage(options.debug, 'response end', 'append chunk=' + chunk);
         finalBuf = Buffer.from(appendChunk(resBodyBuf, chunk));
+      }
+
+      // we compare the final combined size of the buffer.
+      if (finalBuf && finalBuf.length > options.responseMaxBodySizeLimit) {
+        finalBuf = '{ "msg": "response.body.length is over ' + options.responseMaxBodySizeLimit + '. Body was truncated before being logged." }';
       }
 
       res._mo_end(chunk, encoding, callback);


### PR DESCRIPTION
Fix: Read req/res body only if logBody config option is enabled
Refactor: Add config option for body size limit
Refactor: Update README.md